### PR TITLE
Monad instance for Codec'

### DIFF
--- a/Data/Aeson/Codec.hs
+++ b/Data/Aeson/Codec.hs
@@ -33,7 +33,7 @@ type ObjectBuilder = Const (Endo [ Pair ])
 type ObjectCodec a = Codec ObjectParser ObjectBuilder a
 
 -- | Produce a key-value pair.
-pair :: ToJSON a => T.Text -> a -> ObjectBuilder ()
+pair :: ToJSON a => T.Text -> a -> ObjectBuilder b
 pair key val = Const $ Endo ((key .= val):)
 
 -- | Read\/write a given value from/to a given key in the current object, using a given sub-codec.

--- a/Data/Binary/Bits/Codec.hs
+++ b/Data/Binary/Bits/Codec.hs
@@ -10,6 +10,7 @@ import Control.Applicative
 import qualified Data.Binary.Bits.Get as G
 import Data.Binary.Bits.Put
 import qualified Data.Binary.Codec as B
+import Data.Functor ((<$))
 
 import Data.Codec
 import Data.Word
@@ -17,21 +18,21 @@ import Data.Word
 type BitCodec a = Codec G.Block BitPut a
 
 bool :: BitCodec Bool
-bool = Codec G.bool putBool
+bool = codec G.bool putBool
 
 word8 :: Int -> BitCodec Word8
-word8 = Codec <$> G.word8 <*> putWord8
+word8 = codec <$> G.word8 <*> putWord8
 
 word16be :: Int -> BitCodec Word16
-word16be = Codec <$> G.word16be <*> putWord16be
+word16be = codec <$> G.word16be <*> putWord16be
 
 word32be :: Int -> BitCodec Word32
-word32be = Codec <$> G.word32be <*> putWord32be
+word32be = codec <$> G.word32be <*> putWord32be
 
 word64be :: Int -> BitCodec Word64
-word64be = Codec <$> G.word64be <*> putWord64be
+word64be = codec <$> G.word64be <*> putWord64be
 
 -- | Convert a `BitCodec` into a `B.BinaryCodec`.
 toBytes :: BitCodec a -> B.BinaryCodec a
 toBytes (Codec r w)
-  = Codec (G.runBitGet $ G.block r) (runBitPut . w)
+  = codec (G.runBitGet $ G.block r) (runBitPut . (() <$) . w)

--- a/Data/Binary/Codec.hs
+++ b/Data/Binary/Codec.hs
@@ -27,42 +27,42 @@ byteString :: Int -> BinaryCodec BS.ByteString
 byteString n = Codec
   { parse = getByteString n
   , produce = \bs -> if BS.length bs == n
-      then putByteString bs
+      then putByteString bs >> return bs
       else fail "ByteString wrong size for field."
   }
 
 word8 :: BinaryCodec Word8
-word8 = Codec getWord8 putWord8
+word8 = codec getWord8 putWord8
 
 word16be :: BinaryCodec Word16
-word16be = Codec getWord16be putWord16be
+word16be = codec getWord16be putWord16be
 
 word16le :: BinaryCodec Word16
-word16le = Codec getWord16le putWord16le
+word16le = codec getWord16le putWord16le
 
 word16host :: BinaryCodec Word16
-word16host = Codec getWord16host putWord16host
+word16host = codec getWord16host putWord16host
 
 word32be :: BinaryCodec Word32
-word32be = Codec getWord32be putWord32be
+word32be = codec getWord32be putWord32be
 
 word32le :: BinaryCodec Word32
-word32le = Codec getWord32le putWord32le
+word32le = codec getWord32le putWord32le
 
 word32host :: BinaryCodec Word32
-word32host = Codec getWord32host putWord32host
+word32host = codec getWord32host putWord32host
 
 word64be :: BinaryCodec Word64
-word64be = Codec getWord64be putWord64be
+word64be = codec getWord64be putWord64be
 
 word64le :: BinaryCodec Word64
-word64le = Codec getWord64le putWord64le
+word64le = codec getWord64le putWord64le
 
 word64host :: BinaryCodec Word64
-word64host = Codec getWord64host putWord64host
+word64host = codec getWord64host putWord64host
 
 wordhost :: BinaryCodec Word
-wordhost = Codec getWordhost putWordhost
+wordhost = codec getWordhost putWordhost
 
 -- | Convert a `BinaryCodec` into a `ConcreteCodec` on lazy `LBS.ByteString`s.
 toLazyByteString :: BinaryCodec a -> ConcreteCodec LBS.ByteString (Either String) a
@@ -70,4 +70,4 @@ toLazyByteString (Codec r w) = concrete
   (\bs -> case runGetOrFail r bs of
     Left ( _ , _, err ) -> Left err
     Right ( _, _, x ) -> Right x)
-  (runPut . w)
+  (runPut . (>> return ()) . w)

--- a/Foreign/Codec.hs
+++ b/Foreign/Codec.hs
@@ -7,6 +7,7 @@ module Foreign.Codec
   ) where
 
 import Control.Monad.Reader
+import Data.Functor ((<$))
 import Foreign
 
 import Data.Codec.Codec
@@ -26,7 +27,7 @@ peekWith (Codec r _)
 -- | Poke a value using a `ForeignCodec'`.
 pokeWith :: ForeignCodec' p a -> Ptr p -> a -> IO ()
 pokeWith (Codec _ w) ptr x
-  = runReaderT (w x) ptr
+  = runReaderT (() <$ w x) ptr
 
 -- | A codec for a field of a foreign structure, given its byte offset and a sub-codec.
 -- You can get an offset easily using @{#offset struct_type, field}@ with @hsc2hs@.
@@ -38,7 +39,7 @@ field off cd = Codec
 
 -- | A `ForeignCodec` for any `Storable` type.
 storable :: Storable a => ForeignCodec a
-storable = Codec (ReaderT peek) (\x -> ReaderT (`poke`x))
+storable = codec (ReaderT peek) (\x -> ReaderT (`poke`x))
 
 castContext :: ForeignCodec' c a -> ForeignCodec' c' a
 castContext = mapCodecF castc castc


### PR DESCRIPTION
This builds on top of PR #4 to use `Codec'` as a `Monad`.

This allows to parse formats that are prefixed with some metadata that determines the rest of the encoding. For instance, a bytestring can be encoded with its length first:

```
byteStringCodec
  :: Codec fr fw Int -- Length
  -> (Int -> Codec fr fw ByteString) -- A bytestring of fixed length
  -> Codec fr fw ByteString
byteStringCodec codecLength codecBS = do
  n <- BS.length =. codecLength
  codecBS n
```

I have put this in a separate PR because it is a breaking change.
- `Codec'` has a slightly different definition;
- some functions have more constrained types (a `Functor fw` constraint).

While #4 is not strictly required for the instance, the ability to (co)map over the `w` parameter is crucial to make that instance usable.

If you are interested in merging this, I can write some documentation about how to use write monadic `Codec`s before that happens.
